### PR TITLE
Fix result loop and improve static scraping

### DIFF
--- a/core/static_scraper.py
+++ b/core/static_scraper.py
@@ -31,7 +31,12 @@ class StaticScraper:
     """Utility class for scraping static pages via Requests and BeautifulSoup."""
 
     @staticmethod
-    def scrape(url: str, selector: str, attr: Optional[str] = None) -> List[ScrapedItem]:
+    def scrape(
+        url: str,
+        selector: str,
+        attr: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> List[ScrapedItem]:
         """
         Fetch the given URL, parse it and extract elements matching the CSS
         selector. For each element found, return its text and a dictionary of
@@ -54,7 +59,15 @@ class StaticScraper:
             A list of ScrapedItem instances containing the extracted
             content.
         """
-        response = requests.get(url, timeout=10)
+        default_headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/122.0 Safari/537.36"
+            )
+        }
+        all_headers = {**default_headers, **(headers or {})}
+        response = requests.get(url, headers=all_headers, timeout=10)
         response.raise_for_status()
         soup = BeautifulSoup(response.text, "html.parser")
         items: List[ScrapedItem] = []

--- a/gui/dynamic_panel.py
+++ b/gui/dynamic_panel.py
@@ -324,7 +324,6 @@ class DynamicPanel(QWidget):
             for col, key in enumerate(cols):
                 value = item.get(key, "")
                 self.table.setItem(row, col, QTableWidgetItem(str(value)))
-        self.result_signal.emit(data)
 
 
 # ====== Helper Dialog Classes ======

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -144,7 +144,6 @@ class MainWindow(QMainWindow):
         self.dynamic_panel.run_requested.connect(self.handle_dynamic_run)
         self.dynamic_panel.stop_requested.connect(self.stop_dynamic_run)
         self.dynamic_panel.log_signal.connect(self.append_log)
-        self.dynamic_panel.result_signal.connect(self.handle_dynamic_result)
 
         # Placeholder for running thread
         self.scenario_thread: ScenarioThread | None = None


### PR DESCRIPTION
## Summary
- stop dynamic panel from re-emitting results and remove unused connection
- set browser-like User-Agent for static scraper requests

## Testing
- `pytest -q`
- `pip install requests bs4 lxml` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b139b41fe883308a77bb4edf804948